### PR TITLE
Add MathiasKoch to maintainer list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ We're happy to be added as Owners on crates.io for projects we host. We can then
 * James Munns - [Github](https://github.com/jamesmunns)
 * Vadim Kaushan - [Github](https://github.com/disasm)
 * Diego Barrios Romero - [Github](https://github.com/eldruin)
+* Mathias Koch - [Github](https://github.com/MathiasKoch)
 
 [OSI]: https://en.wikipedia.org/wiki/Open_Source_Initiative
 [REWG]: https://github.com/rust-embedded


### PR DESCRIPTION
As with Ryan in #10, i was approached by @eldruin about helping out with supporting `embedded-nal`, which i of course can spare some time for.

This PR adds myself to the list of maintainers in REC.

Of relevant stuff about myself, i can say that we are running embedded rust IoT devices in production at my workplace, developed by me. 

We have a stack making use of a larger number of projects we have OS'ed, a lot of which is still WIP, including:
- https://github.com/BlackbirdHQ/atat/
- https://github.com/BlackbirdHQ/ublox-cellular-rs/ 
- https://github.com/BlackbirdHQ/ublox-short-range-rs/
- https://github.com/BlackbirdHQ/mqttrust/
- https://github.com/BlackbirdHQ/rustot/
- https://github.com/BlackbirdHQ/defmt-persist
- https://github.com/BlackbirdHQ/at-cryptoauth-rs

Other than that i am also an active contributor and maintainer of the HAL we are using: https://github.com/stm32-rs/stm32l4xx-hal